### PR TITLE
fix: Replace set-output command with environment files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,4 +51,4 @@ echo "Convert SARIF file $1"
 # --labels
 # sarif-file-path
 npx @security-alert/sarif-to-issue --dryRun "$DRY_RUN" --token "$TOKEN" --owner "$OWNER" --sarifContentOwner "$OWNER" --repo "$REPO" --sarifContentRepo "$REPO" --sarifContentBranch "$BRANCH" --title "$TITLE" --labels "$LABELS" "$SARIF_FILE"
-echo "::set-output name=output::$?"
+echo "output=$?" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Pull Request

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] pre-commit was run locally and any changes were pushed
- [x] test/test.sh has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->
entrypoint.sh currently uses set-output to return the output of sarifContentRepo. This creates a warning on any workflow currently using this action.
<!-- Issues are expected for both bug fixes and features. -->

Issue URL: https://github.com/sett-and-hive/sarif-to-issue-action/issues/1085

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Replaces set-output with environment files in entrypoint.sh

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
